### PR TITLE
Set websocket max_size to 2**24.

### DIFF
--- a/src/bloxroute_cli/provider/cloud_wss_provider.py
+++ b/src/bloxroute_cli/provider/cloud_wss_provider.py
@@ -75,4 +75,4 @@ class CloudWssProvider(WsProvider):
         self.ssl_context = context
 
     async def connect_websocket(self) -> websockets.WebSocketClientProtocol:
-        return await websockets.connect(self.uri, ssl=self.ssl_context)
+        return await websockets.connect(self.uri, ssl=self.ssl_context, max_size=2**24)

--- a/src/bloxroute_cli/provider/ws_provider.py
+++ b/src/bloxroute_cli/provider/ws_provider.py
@@ -75,7 +75,7 @@ class WsProvider(AbstractWsProvider):
             self.ssl_context = None
 
     async def connect_websocket(self) -> websockets.WebSocketClientProtocol:
-        return await websockets.connect(self.uri, extra_headers=self.headers, ssl=self.ssl_context)
+        return await websockets.connect(self.uri, extra_headers=self.headers, ssl=self.ssl_context, max_size=2**24)
 
     async def call_bx(
         self,


### PR DESCRIPTION
In bxcommon commit a3f68b623afc20cf5bbe773bc09eae32fafe5261, max_size
was set to 2**24. Without it, the websocket connection may break when
streaming blocks containing many transactions.

As WsProvider and CloudWssProvider override AbstractWsProvider's
connect_websocket() and aren't inheriting the max_size setting, set it
manually for them.